### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/io.github.dlippok.photometric-viewer.yaml
+++ b/io.github.dlippok.photometric-viewer.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.dlippok.photometric-viewer
 runtime: org.gnome.Platform
-runtime-version: "45"
+runtime-version: "47"
 sdk: org.gnome.Sdk
 command: photometric-viewer
 finish-args:


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.